### PR TITLE
link to win32 downloads page

### DIFF
--- a/README
+++ b/README
@@ -22,3 +22,6 @@ No modification to the source code was necessary.  Visual Studio 2008 Solution
 files are in the msvc folder.  If you want to build the .msi installer you'll
 need Wix.
 
+Windows downloads:
+
+https://github.com/maoserr/splint_win32/downloads


### PR DESCRIPTION
Link to the hidden downloads page. Long term, splint artifacts should be posted to the Releases page. For now, it would be nice for users to be able to easily navigate to the correct download page from the main GitHub splint project page.